### PR TITLE
Updated variable names for 'active_proportion_of_interval'

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -184,6 +184,3 @@ DEPENDENCIES
   simplecov
   test-unit
   timecop
-
-BUNDLED WITH
-   1.10.4

--- a/lib/devise_user_metering/model.rb
+++ b/lib/devise_user_metering/model.rb
@@ -4,14 +4,33 @@ module Devise
   module Models
     module UserMetering
       
-      #this function is used to calculate the standard activity for the month of the time passed in
+      # takes a time
+      # returns a decimal between 0 and 1 that reflects the proportion of time in the given month
+      # that the user has been 'active'
       def active_proportion_of_month(time)
         active_proportion(time, time.beginning_of_month, time.end_of_month)
       end
       
       #this function is used to calculate the standard activity for the custom interval passed in
-      def active_proportion_of_interval(time, time_start, time_end)
-        active_proportion(time, time_start, time_end)
+      def active_proportion_of_interval(time, interval_start, interval_end)
+        if interval_end > Time.now
+          raise StandardError.new("You can't get meter data for partial intervals")
+        end
+        if interval_start < self.activated_at
+          raise StandardError.new('No usage data retained for this period of time')
+        end
+
+        in_interval = ->(time) { (interval_start..interval_end).cover?(time) }
+        if in_interval.call(self.activated_at) || in_interval.call(self.deactivated_at)
+          if !active && self.deactivated_at < interval_start
+            return 0
+          end
+          interval_duration = interval_end - interval_start
+          remainder = self.active ? [interval_end - self.activated_at, 0].max : 0
+          (remainder + self.rollover_active_duration) / interval_duration
+        else
+          self.active ? 1 : 0
+        end 
       end
 
       #activates the user to indicate the start of metering
@@ -34,30 +53,6 @@ module Devise
       def billed!
         self.rollover_active_duration = 0
         self.save!
-      end
-      
-      private
-      
-      # This function returns a decimal between 0 and 1 that reflects the amount of the month this user has been 'active'
-      def active_proportion(time, month, end_month)
-        if end_month > Time.now
-          raise StandardError.new("You can't get meter data for incomplete months")
-        end
-        if month < self.activated_at.beginning_of_month
-          raise StandardError.new("No usage data retained for that month")
-        end
-
-        in_month = ->(time) { (month..end_month).cover?(time) }
-        if in_month.call(self.activated_at) || in_month.call(self.deactivated_at)
-          if !active && self.deactivated_at < month
-            return 0
-          end
-          month_duration = end_month - month
-          remainder = self.active ? [end_month - self.activated_at, 0].max : 0
-          (remainder + self.rollover_active_duration) / month_duration
-        else
-          self.active ? 1 : 0
-        end        
       end
       
     end

--- a/lib/devise_user_metering/model.rb
+++ b/lib/devise_user_metering/model.rb
@@ -16,7 +16,7 @@ module Devise
         if interval_end > Time.now
           raise StandardError.new("You can't get meter data for partial intervals")
         end
-        if interval_start < self.activated_at.beginning_of_month
+        if usage_in_interval?(interval_start, interval_end)
           raise StandardError.new('No usage data retained for this period of time')
         end
 
@@ -54,7 +54,13 @@ module Devise
         self.rollover_active_duration = 0
         self.save!
       end
-      
+
+      private
+
+      def usage_in_interval?(interval_start, interval_end)
+        (self.deactivated_at && self.deactivated_at < interval_start) ||
+          (self.activated_at && self.activated_at > interval_end)
+      end   
     end
   end
 end

--- a/lib/devise_user_metering/model.rb
+++ b/lib/devise_user_metering/model.rb
@@ -4,19 +4,19 @@ module Devise
   module Models
     module UserMetering
       
-      # takes a time
-      # returns a decimal between 0 and 1 that reflects the proportion of time in the given month
-      # that the user has been 'active'
+      # takes a time, returns the active interval in that time's month
       def active_proportion_of_month(time)
-        active_proportion(time, time.beginning_of_month, time.end_of_month)
+        active_proportion_of_interval(time.beginning_of_month, time.end_of_month)
       end
       
-      #this function is used to calculate the standard activity for the custom interval passed in
-      def active_proportion_of_interval(time, interval_start, interval_end)
+      # takes an interval start and interval end
+      # returns a decimal between 0 and 1 that reflects the proportion of time in the given interval
+      # that the user has been 'active'
+      def active_proportion_of_interval(interval_start, interval_end)
         if interval_end > Time.now
           raise StandardError.new("You can't get meter data for partial intervals")
         end
-        if interval_start < self.activated_at
+        if interval_start < self.activated_at.beginning_of_month
           raise StandardError.new('No usage data retained for this period of time')
         end
 

--- a/test/test_devise_user_metering.rb
+++ b/test/test_devise_user_metering.rb
@@ -21,7 +21,7 @@ class UserTest < Test::Unit::TestCase
   should "Track users with an optional custom time span passed in" do
     u =  new_user(activated_at: Time.parse("2015-01-01"), active: true, rollover_active_duration: 0)
     Timecop.freeze(Date.parse("2015-03-20")) do
-       assert_equal 1, u.active_proportion_of_interval(Time.parse("2015-03-15"), Time.parse("2015-01-15"), Time.parse("2015-02-15"))
+       assert_equal 1, u.active_proportion_of_interval(Time.parse("2015-01-15"), Time.parse("2015-02-15"))
     end
   end
 


### PR DESCRIPTION
Just updated variable names, also have a concern over a line in active_proportion_of_interval one sec. (more obvious with var name changes)
